### PR TITLE
Short cut profile selection via argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Easily switch between AWS Profiles
 
 <img src="assets/demo.gif" width="500">
 
+It is possible to short cut the menu selection by passing
+the profile name you want to switch to as an argument.
+
+```sh
+> awsd work
+Profile work set.
+```
+
+
 ## Requirements
 min go 1.16
 

--- a/main.go
+++ b/main.go
@@ -56,12 +56,12 @@ func main() {
 		for _, profile := range profiles {
 			if profile == desiredProfile {
 				writeFile(desiredProfile, home)
-				fmt.Printf(NoticeColor+"Profile %s set.\n", desiredProfile)
+				fmt.Printf("%s Profile %s set.\n", NoticeColor, desiredProfile)
 				return
 			}
 		}
 		// print a warning if desired profile does not exist
-		fmt.Printf(NoticeColor+"WARNING: Profile %s does not exist.\n", desiredProfile)
+		fmt.Printf("%s WARNING: Profile %s does not exist.\n", NoticeColor, desiredProfile)
 
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -32,13 +32,15 @@ func main() {
 	// If not argument is passed we will prompt the user to select a profile.
 	var desiredProfile = ""
 
-	if len(os.Args) > 1 && os.Args[1] == "version" {
-		fmt.Println("awsd version", version)
-		os.Exit(0)
-	} else if len(os.Args) > 1 && os.Args[1] != "version" {
-		// if there is an argument, and it is not "version"
-		// assume it is the desired profile value
-		desiredProfile = os.Args[1]
+	if len(os.Args) > 1 {
+		if os.Args[1] == "version" {
+			fmt.Println("awsd version", version)
+			os.Exit(0)
+		} else {
+			// if there is an argument, and it is not "version"
+			// assume it is the desired profile value
+			desiredProfile = os.Args[1]
+		}
 	}
 
 	home := os.Getenv("HOME")

--- a/main.go
+++ b/main.go
@@ -38,7 +38,6 @@ func main() {
 	} else if len(os.Args) > 1 && os.Args[1] != "version" {
 		// if there is an argument, and it is not "version"
 		// assume it is the desired profile value
-		fmt.Println("desired profile", os.Args[1])
 		desiredProfile = os.Args[1]
 	}
 

--- a/main.go
+++ b/main.go
@@ -56,13 +56,17 @@ func main() {
 		for _, profile := range profiles {
 			if profile == desiredProfile {
 				writeFile(desiredProfile, home)
-				fmt.Printf("%s Profile %s set.\n", NoticeColor, desiredProfile)
+				fmt.Printf(PromptColor, "Profile ")
+				fmt.Printf(CyanColor, desiredProfile)
+				fmt.Printf(PromptColor, " set. \n")
 				return
 			}
 		}
 		// print a warning if desired profile does not exist
-		fmt.Printf("%s WARNING: Profile %s does not exist.\n", NoticeColor, desiredProfile)
-
+		fmt.Printf(NoticeColor, "WARNING: ")
+		fmt.Printf(PromptColor, "Profile ")
+		fmt.Printf(CyanColor, desiredProfile)
+		fmt.Printf(PromptColor, " does not exist. \n")
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -54,17 +54,13 @@ func main() {
 		for _, profile := range profiles {
 			if profile == desiredProfile {
 				writeFile(desiredProfile, home)
-				fmt.Printf(PromptColor, "Profile ")
-				fmt.Printf(CyanColor, desiredProfile)
-				fmt.Printf(PromptColor, " set. \n")
+				fmt.Printf(NoticeColor+"Profile %s set.\n", desiredProfile)
 				return
 			}
 		}
 		// print a warning if desired profile does not exist
-		fmt.Printf(NoticeColor, "WARNING: ")
-		fmt.Printf(PromptColor, "Profile ")
-		fmt.Printf(CyanColor, desiredProfile)
-		fmt.Printf(PromptColor, " does not exist. \n")
+		fmt.Printf(NoticeColor+"WARNING: Profile %s does not exist.\n", desiredProfile)
+
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ const (
 	CyanColor   = "\033[0;36m%s\033[0m"
 )
 
-var version string = "v0.0.4"
+var version string = "v0.0.5"
 
 func newPromptUISearcher(items []string) list.Searcher {
 	return func(searchInput string, itemIndex int) bool {
@@ -27,10 +27,21 @@ func newPromptUISearcher(items []string) list.Searcher {
 }
 
 func main() {
+	// if a value is passed as and argument and the value is not "version"
+	// we will assume it is the desired profile value and try to set it.
+	// If not argument is passed we will prompt the user to select a profile.
+	var desiredProfile = ""
+
 	if len(os.Args) > 1 && os.Args[1] == "version" {
 		fmt.Println("awsd version", version)
 		os.Exit(0)
+	} else if len(os.Args) > 1 && os.Args[1] != "version" {
+		// if there is an argument, and it is not "version"
+		// assume it is the desired profile value
+		fmt.Println("desired profile", os.Args[1])
+		desiredProfile = os.Args[1]
 	}
+
 	home := os.Getenv("HOME")
 	profileFileLocation := getenv("AWS_CONFIG_FILE", fmt.Sprintf("%s/.aws/config", home))
 	profiles := getProfiles(profileFileLocation)
@@ -38,6 +49,26 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	if desiredProfile != "" {
+		//check if desired profile exists
+		for _, profile := range profiles {
+			if profile == desiredProfile {
+				writeFile(desiredProfile, home)
+				fmt.Printf(PromptColor, "Profile ")
+				fmt.Printf(CyanColor, desiredProfile)
+				fmt.Printf(PromptColor, " set. \n")
+				return
+			}
+		}
+		// print a warning if desired profile does not exist
+		fmt.Printf(NoticeColor, "WARNING: ")
+		fmt.Printf(PromptColor, "Profile ")
+		fmt.Printf(CyanColor, desiredProfile)
+		fmt.Printf(PromptColor, " does not exist. \n")
+		return
+	}
+
 	fmt.Printf(NoticeColor, "AWS Profile Switcher\n")
 	prompt := promptui.Select{
 		Label:        fmt.Sprintf(PromptColor, "Choose a profile"),

--- a/scripts/_awsd
+++ b/scripts/_awsd
@@ -5,7 +5,15 @@ if [[ "$1" == "version" ]]; then
   return
 fi
 
-AWS_PROFILE="$AWS_PROFILE" _awsd_prompt
+# check if $1 is empty
+if [ -z "$1" ]
+then
+  # no argument passed
+  AWS_PROFILE="$AWS_PROFILE" _awsd_prompt
+else
+  # argument passed, assume it's a profile name
+  AWS_PROFILE="$AWS_PROFILE" _awsd_prompt "$1"
+fi
 
 selected_profile="$(cat ~/.awsd)"
 


### PR DESCRIPTION
This change adds support for passing arbitrary was profile names as arguments, if the profile name exists in the users list of profiles then that profile will be set, if not a warning is displayed. If no argument or and argument of "version" is passed the behaviour is unchanged.

My rationale is that I often know what profile I want to use and as I have a lot of profiles it is usually quicker to type `awsd my-profile` than it is to select from the list, but having the list is handy for those time when I need to use a not often used profile too.