### PR TITLE
feat: add '-h' flag for help command

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -53,7 +53,6 @@ func runProfileSwitcher() error {
 }
 
 func shouldRunDirectProfileSwitch() bool {
-	invalidProfiles := []string{"l", "list", "completion", "help", "--help", "v", "version"}
 	invalidProfiles := []string{"l", "list", "completion", "help", "--help", "-h", "v", "version"}
 	return len(os.Args) > 1 && !utils.Contains(invalidProfiles, os.Args[1])
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -54,6 +54,7 @@ func runProfileSwitcher() error {
 
 func shouldRunDirectProfileSwitch() bool {
 	invalidProfiles := []string{"l", "list", "completion", "help", "--help", "v", "version"}
+	invalidProfiles := []string{"l", "list", "completion", "help", "--help", "-h", "v", "version"}
 	return len(os.Args) > 1 && !utils.Contains(invalidProfiles, os.Args[1])
 }
 


### PR DESCRIPTION
add `-h` to list of available commands / flags to `invalidProfiles` making `-h` flag available.

This fixes #20 